### PR TITLE
increase the delay between drawing calls

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -466,7 +466,7 @@ var drawInterval
 function drawTorrent (torrent) {
   if (!argv.quiet) {
     process.stdout.write(new Buffer('G1tIG1sySg==', 'base64')) // clear for drawing
-    drawInterval = setInterval(draw, 500)
+    drawInterval = setInterval(draw, 1000)
     unref(drawInterval)
   }
 


### PR DESCRIPTION
Sometimes the `drawInterval` won't call itself on my system - leaving a blank terminal like its still waiting to connect. Not sure whats the issue, but increasing the timer ensures that it always renders on the screen (in addition the drawing updates in sync with the [runtime] (https://github.com/feross/webtorrent-cli/blob/master/bin/cmd.js#L80)).