### PR TITLE
Fix a VLC detection bug

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -370,16 +370,14 @@ function runDownload (torrentId) {
     if (argv.vlc && process.platform === 'win32') {
       var Registry = require('winreg')
 
-      var key
-      if (process.arch === 'x64') {
+      var key = new Registry({
+        hive: Registry.HKLM,
+        key: '\\Software\\VideoLAN\\VLC'
+      })
+      if(!key) {
         key = new Registry({
           hive: Registry.HKLM,
           key: '\\Software\\Wow6432Node\\VideoLAN\\VLC'
-        })
-      } else {
-        key = new Registry({
-          hive: Registry.HKLM,
-          key: '\\Software\\VideoLAN\\VLC'
         })
       }
 


### PR DESCRIPTION
If you were on a x64 Windows OS and had installed the 64bit version of VLC, it was not detected previously. This is a patch to fix that.