### PR TITLE
NPM preferGlobal

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,6 @@
   "scripts": {
     "test": "standard && tape test.js",
     "update-authors": "./bin/update-authors.sh"
-  }
+  },
+  "preferGlobal": true
 }


### PR DESCRIPTION
"If your package is primarily a command-line application that should be installed globally, then set this value to true to provide a warning if it is installed locally.

It doesn't actually prevent users from installing it locally, but it does help prevent some confusion if it doesn't work as expected."