### PR TITLE
Use latest webtorrent

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "network-address": "^1.1.0",
     "parse-torrent": "^5.7.3",
     "prettier-bytes": "^1.0.3",
-    "webtorrent": "^0.88.1",
+    "webtorrent": "^0.x",
     "winreg": "^1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "network-address": "^1.1.0",
     "parse-torrent": "^5.7.3",
     "prettier-bytes": "^1.0.3",
-    "webtorrent": "^0.x",
+    "webtorrent": "0.x",
     "winreg": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
As ^ only works from 1.0.0, it should be just "0.x" like [webtorrent-hybrid](https://github.com/feross/webtorrent-hybrid/blob/master/package.json#L17)