### PR TITLE
Fixed keybindings issue for OMX player

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -90,7 +90,7 @@ if (process.env.DEBUG) {
 }
 var MPLAYER_EXEC = 'mplayer -ontop -really-quiet -noidx -loop 0'
 var MPV_EXEC = 'mpv --ontop --really-quiet --loop=no'
-var OMX_EXEC = 'omxplayer -r -o ' + (typeof argv.omx === 'string' ? argv.omx : 'hdmi')
+var OMX_EXEC = 'lxterminal -e omxplayer -r -o ' + (typeof argv.omx === 'string' ? argv.omx : 'hdmi')
 
 if (argv.subtitles) {
   VLC_ARGS += ' --sub-file=' + argv.subtitles


### PR DESCRIPTION
Fixes #7

OMX needs a separate terminal to register the keystrokes. This hack spawns a terminal to invoke omx which enables the recognition of the keybindings again (quit, seek, etc.). The moment the player exits, the terminal does too so it would be somewhat unobtrusive.

Only tested on a Raspberry Pi 3.