### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:onbuild
+
+ENTRYPOINT [ "node", "bin/cmd.js" ]


### PR DESCRIPTION
Add Dockerfile to enable image building.
By now, I use the official Node image, 'onbuild' tag. More info at https://hub.docker.com/_/node/ . Should the build be pinned to any specific version, let me know.

Build:

```
$ docker build -t webtorrent-cli .
```

Run:

```
$ docker run -rm -it --name webtorrent -p 8000:8000 webtorrent-cli <magnet-link>
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run -rm -it --name webtorrent -p 8000:8000 pataquets/webtorrent-cli <magnet-link>
```

Using `--rm` instead of `-d` makes the container not go background and it to be deleted after stop. Stop it by `CTRL+C`'ing it. Also, you might want to add one (or more) `-v /host/dir/path:/container/path/` options in order to mount host's directories into the container to use `.torrent` files.

More optional improvements to come:
- Create an 'official' automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/
