### PR TITLE
Improve time displays

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -562,7 +562,9 @@ function drawTorrent (torrent) {
     var linesRemaining = clivas.height
     var peerslisted = 0
     var speed = torrent.downloadSpeed
-    var estimate = moment.duration(torrent.timeRemaining / 1000, 'seconds').humanize()
+    var estimate = torrent.timeRemaining ? moment.duration(torrent.timeRemaining / 1000, 'seconds').humanize() : 'N/A'
+    var runtimeSeconds = getRuntime()
+    var runtime = runtimeSeconds > 300 ? moment.duration(getRuntime(), 'seconds').humanize() : runtimeSeconds + ' seconds'
 
     clivas.clear()
 
@@ -588,7 +590,7 @@ function drawTorrent (torrent) {
       '{green:Uploaded:} {bold:' + prettierBytes(torrent.uploaded) + '}'
     )
     line(
-      '{green:Running time:} {bold:' + getRuntime() + 's}  ' +
+      '{green:Running time:} {bold:' + runtime + '}  ' +
       '{green:Time remaining:} {bold:' + estimate + '}  ' +
       '{green:Peers:} {bold:' + unchoked.length + '/' + torrent.numPeers + '}'
     )


### PR DESCRIPTION
This improves two portions of the display. The "Running time" is now described using moment.js after 5 minutes, and the "Time remaining" now displays as "N/A" when seeding.

Previously, a seeding torrent might look like:

    Running time: 13703s  Time remaining: a few seconds  Peers: 1/1

Now, before 5 minutes it will look like:

    Running time: 72 seconds  Time remaining: N/A  Peers: 1/1

After 5 minutes (300 seconds), we use moment.js:

    Running time: 7 minutes  Time remaining: N/A  Peers: 1/1

The 5 minute cutoff is to prevent moment.js from saying "a few seconds", etc for small time values that might matter to users.