### PR TITLE
Fix queued peers ref. Fixes #25

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -594,7 +594,7 @@ function drawTorrent (torrent) {
     )
     if (argv.verbose) {
       line(
-        '{green:Queued peers:} {bold:' + torrent.numQueued + '}  ' +
+        '{green:Queued peers:} {bold:' + torrent._numQueued + '}  ' +
         '{green:Blocked peers:} {bold:' + blockedPeers + '}  ' +
         '{green:Hotswaps:} {bold:' + hotswaps + '}'
       )


### PR DESCRIPTION
Fixes the reference to the `numQueued` property on torrents to be `_numQueued`.